### PR TITLE
Add `CXX` and `CXXFLAGS` compilation flag vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,14 @@ ifeq ($(VERBOSE),1)
   VERB =
 endif
 
+CXX = clang++
+CXXFLAGS = -pedantic -Wall -Wextra
+
 SRCS_CC := $(wildcard *.cc)
 SRCS_H := $(wildcard *.h)
 
 render: $(SRCS_CC) $(SRCS_H) Makefile
-	$(VERB) clang++ $(SRCS_CC) -o $@
+	$(VERB) $(CXX) $(CXXFLAGS) $(SRCS_CC) -o $@
+
+clean:
+	$(VERB) rm -f render

--- a/main.cc
+++ b/main.cc
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-int main(int argc, char* argv[]) {
+int main() {
   Image img(256, 256);
   img.OutputAsPpm(std::cout);
 }


### PR DESCRIPTION
* enable overriding `clang++` via `$(CXX)`
* add `-pedantic`, `-Wall`, `-Wextra` via `$(CXXFLAGS)`
* remove unused vars from `main()` as a result of flags to ensure we don't have
  any compile-time warnings
* add `make clean` target to clean up the workspace easily