### PR TITLE
Update GitHub Actions to macOS 12 and Ubuntu 22.04

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: C++ CI
+name: C++
 
 on:
   push:
@@ -24,7 +24,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ 'macos-10.15', 'ubuntu-20.04' ]
+        os: [ 'macos-12', 'ubuntu-22.04' ]
 
     runs-on: ${{ matrix.os }}
 
@@ -34,3 +34,6 @@ jobs:
 
       - name: Build
         run: make VERBOSE=1
+
+      - name: Render a simple image
+        run: ./render > /dev/null

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Bloom
 
+[![Build Status][github-ci-badge]][github-ci-url]
+
+[github-ci-badge]: https://github.com/mbrukman/bloom/actions/workflows/cpp.yml/badge.svg?branch=main
+[github-ci-url]: https://github.com/mbrukman/bloom/actions/workflows/cpp.yml?query=branch%3Amain
+
 **Bloom** is an exploration of raytracing, path tracing, physically-based
 rendering, and more.
 


### PR DESCRIPTION
Using the latest versions of both operating systems. Also, run the binary that we have built to see if there is any undefined behavior which was recently enabled during compilation.

Add the GitHub CI badge to the README for visibility.