### PR TITLE
Rename `cpp.yml` -> `main.yml`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: C++
+name: Build
 
 on:
   push:
@@ -21,7 +21,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  Cxx:
     strategy:
       matrix:
         os: [ 'macos-12', 'ubuntu-22.04' ]

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status][github-ci-badge]][github-ci-url]
 
-[github-ci-badge]: https://github.com/mbrukman/bloom/actions/workflows/cpp.yml/badge.svg?branch=main
-[github-ci-url]: https://github.com/mbrukman/bloom/actions/workflows/cpp.yml?query=branch%3Amain
+[github-ci-badge]: https://github.com/mbrukman/bloom/actions/workflows/main.yml/badge.svg?branch=main
+[github-ci-url]: https://github.com/mbrukman/bloom/actions/workflows/main.yml?query=branch%3Amain
 
 **Bloom** is an exploration of raytracing, path tracing, physically-based
 rendering, and more.


### PR DESCRIPTION
Also rename the overall CI config from "C++" to "Build" and C++ can be one of the jobs; this will let us amortize the high cost of booting a new VM or starting a container, and run several jobs inside each OS image for efficiency.

Update the CI badge in the README accordingly.